### PR TITLE
Develop 0.4.5

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -10,6 +10,7 @@
 -->
 
 <!-- 💡 ToDo
+- logにDAJIN2のバージョンを出力する
 - VCF、PDFを出力する
 - 逆位アレルでの検証を加える
 - nCATSがほしい…
@@ -17,8 +18,19 @@
 - Flaskではなく、streamlitでGUIを作る
  -->
 
-# v0.4.4 (2024-04-23)
+v0.4.5 (2024-04-24)
 
+## 🐛 Bug Fixes
+
++ In version 0.4.4 of strand_bias_handler.remove_biased_clusters, there was an error in the continuation condition for removing biased clusters, which has now been corrected. The correct condition should be 'there are alleles with and without strand bias **and** the iteration count is less than or equal to 1000'. Instead, it was incorrectly set to 'there are alleles with and without strand bias **or** the iteration count is less than or equal to 1000'. [Commit Detail](https://github.com/akikuno/DAJIN2/commit/b72b3855121d0da6ac80636089315ecc26464657)
+
+
+-------------------------------------------------------------
+
+# Past Releases
+
+<details>
+<summary> v0.4.4 (2024-04-23) </summary>
 
 ## 💥 Breaking
 
@@ -42,11 +54,7 @@
 + Add type hints and comments in `return_labels` [Commit Detail](https://github.com/akikuno/DAJIN2/commit/02fd72d040865c1c8c81015d965ae12f6788b422)
 
 
-
-
--------------------------------------------------------------
-
-# Past Releases
+</details>
 
 <details>
 <summary> v0.4.3 (2024-03-29) </summary>

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("requirements.txt") as requirements_file:
 
 setuptools.setup(
     name="DAJIN2",
-    version="0.4.4",
+    version="0.4.5",
     author="Akihiro Kuno",
     author_email="akuno@md.tsukuba.ac.jp",
     description="One-step genotyping tools for targeted long-read sequencing",

--- a/src/DAJIN2/core/clustering/strand_bias_handler.py
+++ b/src/DAJIN2/core/clustering/strand_bias_handler.py
@@ -105,7 +105,7 @@ def remove_biased_clusters(path_sample: Path, path_score_sample: Path, labels: l
 
     iteration_count = 0
     labels_corrected = labels
-    while len(set(strand_biases.values())) > 1 or iteration_count < 1000:
+    while len(set(strand_biases.values())) > 1 and iteration_count < 1000:
         scores = io.read_jsonl(path_score_sample)
         train_data, train_labels, test_data = prepare_training_testing_sets(labels, scores, strand_biases)
         dtree = train_decision_tree(train_data, train_labels)

--- a/src/DAJIN2/main.py
+++ b/src/DAJIN2/main.py
@@ -20,7 +20,7 @@ from DAJIN2.core import core
 from DAJIN2.utils import io, config, report_generator, input_validator, multiprocess
 
 
-DAJIN_VERSION = "0.4.4"
+DAJIN_VERSION = "0.4.5"
 
 
 def generate_report(name: str) -> None:


### PR DESCRIPTION
## 🐛 Bug Fixes

+ In version 0.4.4 of strand_bias_handler.remove_biased_clusters, there was an error in the continuation condition for removing biased clusters, which has now been corrected. The correct condition should be 'there are alleles with and without strand bias **and** the iteration count is less than or equal to 1000'. Instead, it was incorrectly set to 'there are alleles with and without strand bias **or** the iteration count is less than or equal to 1000'.