### PR TITLE
Develop v0.5.4

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -25,6 +25,11 @@
   + The following termination criterion has been removed:
     - Adjusted Rand Index >= 0.95, as it led to early termination when minor clusters were generated.
 
++ The threshold for `clustering.strand bias` determination has been loosened. [[Commit Detail](https://github.com/akikuno/DAJIN2/commit/5bbaa7d363bce03d6fbd4ba7fdf1c00e938d9809)]
+  + This adjustment addresses cases like `+:13, -:2` (0.87) observed in `example_flox/flox-1nt-deletion`.
+  + Since the minor allele is particularly susceptible, further adjustments may be necessary in the future.
+
+
 <!-- ############################################################# # -->
 
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -11,10 +11,36 @@
 -->
 
 <!-- ############################################################# # -->
+# v0.5.4 (2024-XX-XX)
 
-# Current Release
+## 💥 Breaking
 
-# v0.5.3 (2024-XX-XX)
++ Use simulated annealing to optimize cluster assignments in `clustering.constrained_kmenas` [[Commit Detail](https://github.com/akikuno/DAJIN2/commit/b07b626c1def93022e79840e1e6e393fa400cefb)]
+  + Since `ortools` is not installable on osx-arm64 in Bioconda, I implemented alternative smethods to calculate min_cost_flow.
+
++ Change the criteria for terminating clustering. [[Commit Detail](https://github.com/akikuno/DAJIN2/commit/db6ec7245d0d1a7ff7204574cffdfd945ee5e854)]
+  + The following termination criteria have been added:
+    - Minimum cluster size is less than or equal to 0.5% of the sample's read number.
+    - Decrease in the proportion of samples with a silhouette score of 0.25 or higher.
+  + The following termination criterion has been removed:
+    - Adjusted Rand Index >= 0.95, as it led to early termination when minor clusters were generated.
+
+<!-- ############################################################# # -->
+
+
+
+-------------------------------------------------------------
+
+# Past Releases
+
+<!--  ------------------------------------------------------------- -->
+
+<!-- <details>
+<summary> v0.5.3 (2024-07-16) </summary>
+</details> -->
+
+<details>
+<summary> v0.5.3 (2024-07-16) </summary>
 
 ## 💥 Breaking
 
@@ -28,21 +54,8 @@
 - Due to a bias in `classifiler.calc_match` where alleles with shorter sequences were prioritized, the operation of dividing by sequence length has been removed. [[Commit Detail](https://github.com/akikuno/DAJIN2/commit/fa6fbd5a7f9693df3b067a3041df42198a0d65b7)]
 
 - Fix `preporcess.mapping.generate_sam` to perform alignments with `map-ont` and `splice` in addition to `sr` for sequence lengths of 500 bp or less, and select the optimal prefix from these alignments. Issue: #45 [[Commit Detail](https://github.com/akikuno/DAJIN2/commit/9e7fb93f3c7b74095d2afd08bf3fa0bc00e6f367)]
+</details>
 
-
-<!-- ############################################################# # -->
-
-
-
--------------------------------------------------------------
-
-# Past Releases
-
-<!--  ------------------------------------------------------------- -->
-
-<!-- <details>
-<summary> v0.5.0 (2024-06-05) </summary>
-</details> -->
 
 <details>
 <summary> v0.5.2 (2024-07-08) </summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "DAJIN2"
-version = "0.5.3"
+version = "0.5.4"
 description = "One-step genotyping tools for targeted long-read sequencing"
 authors = ["Akihiro Kuno <akuno@md.tsukuba.ac.jp>"]
 readme = "README.md"
@@ -39,7 +39,7 @@ kaleido = ">=0.2.0"
 rapidfuzz = ">=3.6.0"
 scikit-learn = ">=1.3.0"
 ruptures = ">=1.1.8"
-ortools = ">=9.0"
+networkx = ">=3.0"
 
 # BioConda
 mappy = ">=2.24"

--- a/src/DAJIN2/core/clustering/constrained_kmeans.py
+++ b/src/DAJIN2/core/clustering/constrained_kmeans.py
@@ -1,7 +1,7 @@
 """Constrained k-means clustering
 Bradley, Paul S., Kristin P. Bennett, and Ayhan Demiriz. "Constrained k-means clustering." Microsoft Research, Redmond 20.0 (2000): 0.
 
-The implementation is referenced from @kuga-qiita. (https://qiita.com/kuga-qiita/items/5588d5469f3268b7fd39#constrained-k-means-1)
+The implementation is modified from @kuga-qiita. (https://qiita.com/kuga-qiita/items/5588d5469f3268b7fd39#constrained-k-means-1)
 """
 
 from __future__ import annotations
@@ -9,7 +9,6 @@ from __future__ import annotations
 from functools import partial
 
 import numpy as np
-from ortools.graph.python import min_cost_flow
 from scipy.spatial.distance import cdist
 
 
@@ -22,6 +21,29 @@ def random(
     return centers, indices
 
 
+def kmeans_plusplus(X, n_clusters, random_state):
+    n_samples, _ = X.shape
+    centers = np.empty((n_clusters, X.shape[1]), dtype=X.dtype)
+    indices = np.empty(n_clusters, dtype=int)
+
+    center_id = random_state.choice(n_samples)
+    centers[0] = X[center_id]
+    indices[0] = center_id
+
+    closest_dist_sq = np.full(n_samples, np.inf)
+    for i in range(1, n_clusters):
+        dist_sq = np.sum((X - centers[i - 1]) ** 2, axis=1)
+        closest_dist_sq = np.minimum(closest_dist_sq, dist_sq)
+        probs = closest_dist_sq / np.sum(closest_dist_sq)
+        cumulative_probs = np.cumsum(probs)
+        r = random_state.rand()
+        center_id = np.searchsorted(cumulative_probs, r)
+        centers[i] = X[center_id]
+        indices[i] = center_id
+
+    return centers, indices
+
+
 class ConstrainedKMeans:
     def __init__(
         self,
@@ -29,7 +51,7 @@ class ConstrainedKMeans:
         min_cluster_size: int,
         max_cluster_size: int | None = None,
         random_state: int = 0,
-        init: str = "random",
+        init: str = "k-means++",
         n_init: int = 10,
         max_iter: int = 300,
         tol: float = 1e-4,
@@ -57,6 +79,13 @@ class ConstrainedKMeans:
                 random_state=self.random_state,
                 **kwargs,
             )
+        elif init == "k-means++":
+            self.init = partial(
+                kmeans_plusplus,
+                n_clusters=self.n_clusters,
+                random_state=self.random_state,
+                **kwargs,
+            )
 
         self.n_init = n_init
         self.max_iter = max_iter
@@ -65,7 +94,7 @@ class ConstrainedKMeans:
         self.centers = None
         self.labels = None
 
-    def get_smcf_params(self, n_samples: int) -> tuple[np.ndarray, np.ndarray, np.ndarray, list[int]]:
+    def get_lp_params(self, n_samples: int) -> tuple[np.ndarray, np.ndarray, np.ndarray, list[float]]:
         X_nodes = np.arange(n_samples)
         cluster_nodes = np.arange(n_samples, n_samples + self.n_clusters)
         artificial_demand_node = np.array([n_samples + self.n_clusters])
@@ -96,59 +125,92 @@ class ConstrainedKMeans:
         ).tolist()
         return start_nodes, end_nodes, capacities, supplies
 
-    def calc_unit_costs(self, X: np.ndarray, centers: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-        dist_sq = cdist(X, centers, "sqeuclidean")
-        unit_costs = np.concatenate([dist_sq.flatten(), np.zeros(self.n_clusters)])
-        return unit_costs, dist_sq
+    def simulated_annealing(self, X: np.ndarray, centers: np.ndarray) -> np.ndarray:
+        """
+        Perform simulated annealing to optimize cluster assignments.
 
-    def clustering(
-        self,
-        start_nodes: np.ndarray,
-        end_nodes: np.ndarray,
-        capacities: np.ndarray,
-        supplies: list[int],
-        unit_costs: np.ndarray,
-    ) -> np.ndarray:
-        smcf = min_cost_flow.SimpleMinCostFlow()
-        all_arcs = smcf.add_arcs_with_capacity_and_unit_cost(start_nodes, end_nodes, capacities, unit_costs)
-        smcf.set_nodes_supplies(np.arange(len(supplies)), supplies)
-        smcf.solve()
-        solution_flows = smcf.flows(all_arcs)
-        mask = solution_flows[: -self.n_clusters].reshape((-1, self.n_clusters))
+        This method uses simulated annealing to assign data points to clusters,
+        allowing for probabilistic acceptance of worse assignments to escape local optima.
+
+        Parameters:
+        X (np.ndarray): The input data array of shape (n_samples, n_features).
+        centers (np.ndarray): The initial cluster centers of shape (n_clusters, n_features).
+
+        Returns:
+        np.ndarray: A mask array of shape (n_samples, n_clusters) indicating cluster assignments.
+        """
+        n_samples, n_clusters = X.shape[0], self.n_clusters
+        dist_sq = cdist(X, centers, "sqeuclidean")
+        labels = np.argmin(dist_sq, axis=1)
+
+        T = 1.0
+        T_min = 0.0001
+        alpha = 0.9
+
+        while T > T_min:
+            # Vectorize sample processing and compute in batches
+            idx = np.random.randint(0, n_samples, size=1000)
+            current_labels = labels[idx]
+            new_labels = np.random.randint(0, n_clusters, size=1000)
+
+            # Select only the samples where the new label differs from the current label
+            mask = current_labels != new_labels
+            idx = idx[mask]
+            current_labels = current_labels[mask]
+            new_labels = new_labels[mask]
+
+            if len(idx) == 0:
+                T *= alpha
+                continue
+
+            current_dists = dist_sq[idx, current_labels]
+            new_dists = dist_sq[idx, new_labels]
+
+            delta_E = new_dists - current_dists
+            prob = np.exp(-delta_E / T)
+            accept = (delta_E < 0) | (prob > np.random.rand(len(prob)))
+
+            labels[idx[accept]] = new_labels[accept]
+
+            T *= alpha
+
+        mask = np.zeros((n_samples, n_clusters))
+        mask[np.arange(n_samples), labels] = 1
         return mask
+
+    def fit_once(self, X: np.ndarray, **kwargs) -> tuple[np.ndarray, float]:
+        centers_, _ = self.init(X, **kwargs)
+        dist_sq = cdist(X, centers_, "sqeuclidean")
+        mask = self.simulated_annealing(X, centers_)
+        inertia = np.sum(mask * dist_sq)
+        return centers_, inertia
 
     def fit(self, X: np.ndarray) -> ConstrainedKMeans:
         self.valid_tr(X)
         if X.ndim == 1:
             X = X[:, np.newaxis]
-        n_samples, _ = X.shape
-        params = self.get_smcf_params(n_samples)
 
-        best_inertia, centers, self.init_indices = None, None, None
+        best_inertia, best_centers = None, None
         for _ in range(self.n_init):
-            centers_, init_indices_ = self.init(X, **self.kwargs)
-            unit_costs, dist_sq = self.calc_unit_costs(X, centers_)
-            mask = self.clustering(*params, unit_costs)
-            inertia = np.sum(mask * dist_sq)
-            if best_inertia is None or best_inertia > inertia:
+            centers_, inertia = self.fit_once(X, **self.kwargs)
+            if best_inertia is None or inertia < best_inertia:
                 best_inertia = inertia
-                centers = centers_
-                self.init_indices = init_indices_
+                best_centers = centers_
+        self.centers = best_centers
 
-        unit_costs, dist_sq = self.calc_unit_costs(X, centers)
+        dist_sq = cdist(X, self.centers, "sqeuclidean")
 
         for i in range(self.max_iter):
-            mask = self.clustering(*params, unit_costs)
+            mask = self.simulated_annealing(X, self.centers)
             centers_ = np.dot(mask.T, X) / np.sum(mask, axis=0)[:, np.newaxis]
-            unit_costs, dist_sq = self.calc_unit_costs(X, centers_)
-            centers_squared_diff = np.sum((centers_ - centers) ** 2)
-            centers = centers_
+            dist_sq = cdist(X, centers_, "sqeuclidean")
+            centers_squared_diff = np.sum((centers_ - self.centers) ** 2)
+            self.centers = centers_
             iter_ = i
             if centers_squared_diff <= self.tol:
                 break
 
         self.inertia = np.sum(mask * dist_sq)
-        self.centers = centers
         self.labels = np.argmax(mask, axis=-1)
         self.iter_ = iter_
         return self
@@ -160,10 +222,7 @@ class ConstrainedKMeans:
         self.valid_pr(X)
         if X.ndim == 1:
             X = X[:, np.newaxis]
-        n_samples, _ = X.shape
-        params = self.get_smcf_params(n_samples)
-        unit_costs = self.calc_unit_costs(X, self.centers)
-        mask = self.clustering(*params, unit_costs)
+        mask = self.simulated_annealing(X, self.centers)
         labels = np.argmax(mask, axis=1)
         return labels
 
@@ -186,8 +245,8 @@ class ConstrainedKMeans:
             raise TypeError("max_cluster_size must be an integer or None")
         if not isinstance(random_state, int) and random_state is not None:
             raise TypeError("random_state must be an integer")
-        if init not in ["random"]:
-            raise TypeError("init must be 'random'")
+        if init not in ["random", "k-means++"]:
+            raise TypeError("init must be 'random' or 'k-means++'")
         if not isinstance(n_init, int):
             raise TypeError("n_init must be an integer")
         if not isinstance(max_iter, int):

--- a/src/DAJIN2/core/clustering/strand_bias_handler.py
+++ b/src/DAJIN2/core/clustering/strand_bias_handler.py
@@ -17,8 +17,8 @@ Re-allocates reads belonging to clusters with strand bias to clusters without st
 """
 
 # Constants
-STRAND_BIAS_LOWER_LIMIT = 0.1
-STRAND_BIAS_UPPER_LIMIT = 0.9
+STRAND_BIAS_LOWER_LIMIT = 0.2
+STRAND_BIAS_UPPER_LIMIT = 0.8
 
 
 def is_strand_bias(path_control: Path) -> bool:

--- a/src/DAJIN2/utils/config.py
+++ b/src/DAJIN2/utils/config.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from sklearn.exceptions import ConvergenceWarning
 
-DAJIN_VERSION = "0.5.3"
+DAJIN_VERSION = "0.5.4"
 DAJIN_RESULTS_DIR = Path("DAJIN_Results")
 TEMP_ROOT_DIR = Path(DAJIN_RESULTS_DIR, ".tempdir")
 


### PR DESCRIPTION
## 💥 Breaking

+ Use simulated annealing to optimize cluster assignments in `clustering.constrained_kmenas` [[Commit Detail](https://github.com/akikuno/DAJIN2/commit/b07b626c1def93022e79840e1e6e393fa400cefb)]
  + Since `ortools` is not installable on osx-arm64 in Bioconda, I implemented alternative smethods to calculate min_cost_flow.

+ Change the criteria for terminating clustering. [[Commit Detail](https://github.com/akikuno/DAJIN2/commit/db6ec7245d0d1a7ff7204574cffdfd945ee5e854)]
  + The following termination criteria have been added:
    - Minimum cluster size is less than or equal to 0.5% of the sample's read number.
    - Decrease in the proportion of samples with a silhouette score of 0.25 or higher.
  + The following termination criterion has been removed:
    - Adjusted Rand Index >= 0.95, as it led to early termination when minor clusters were generated.

+ The threshold for `clustering.strand bias` determination has been loosened. [[Commit Detail](https://github.com/akikuno/DAJIN2/commit/5bbaa7d363bce03d6fbd4ba7fdf1c00e938d9809)]
  + This adjustment addresses cases like `+:13, -:2` (0.87) observed in `example_flox/flox-1nt-deletion`.
  + Since the minor allele is particularly susceptible, further adjustments may be necessary in the future.
